### PR TITLE
PHP security updates 2020-01

### DIFF
--- a/packages/php7.2/APKBUILD
+++ b/packages/php7.2/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=php7.2
 _pkgreal=php
 _phpver=7.2
-pkgver=7.2.26
+pkgver=7.2.27
 pkgrel=0
 _apiver=20170718
 pkgdesc="The PHP $_phpver language runtime engine"

--- a/packages/php7.3/APKBUILD
+++ b/packages/php7.3/APKBUILD
@@ -1,7 +1,7 @@
 pkgname=php7.3
 _pkgreal=php
 _phpver=7.3
-pkgver=7.3.13
+pkgver=7.3.14
 pkgrel=10
 _apiver=20180731
 pkgdesc="The PHP $_phpver language runtime engine"


### PR DESCRIPTION
Security updates:
- PHP 7.2.27
- PHP 7.3.14

See https://www.php.net/archive/2020.php#2020-01-23-3