### PR TITLE
Update xdebug to 3.1.5

### DIFF
--- a/packages/php8.0-xdebug/APKBUILD
+++ b/packages/php8.0-xdebug/APKBUILD
@@ -2,7 +2,7 @@
 
 pkgname=php8.0-xdebug
 _pkgreal=xdebug
-pkgver=3.0.4
+pkgver=3.1.5
 pkgrel=1
 provides="php-xdebug=8.0"
 pkgdesc="xDebug Profiler"

--- a/packages/php8.1-xdebug/APKBUILD
+++ b/packages/php8.1-xdebug/APKBUILD
@@ -2,7 +2,7 @@
 
 pkgname=php8.1-xdebug
 _pkgreal=xdebug
-pkgver=3.1.1
+pkgver=3.1.5
 pkgrel=1
 provides="php-xdebug=8.1"
 pkgdesc="xDebug Profiler"


### PR DESCRIPTION
xdebug 3.1+ is the preferred supported version for both php 8.0 and 8.1.
https://xdebug.org/docs/compat

> 3.0 is broken with phpstorm 2022.2 in certain situations. https://youtrack.jetbrains.com/issue/WI-67891/Step-Over-broken-for-Xdebug-30-for-static-methods-and-private-properties-from-parent-classes https://youtrack.jetbrains.com/issue/WI-67937/Xdebug-broken-after-update-to-version-20222
