### PR TITLE
Remove Alpine 3.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ platforms: &platforms
   - arm64
 
 alpine-versions: &alpine-versions
-  - "3.18"
   - "3.19"
 
 php-versions: &php-versions


### PR DESCRIPTION
Remove Alpine 3.18 now that we are running 3.19 for all our images.